### PR TITLE
Keywords translation and further improvements (see description)

### DIFF
--- a/pt.lproj/Localizable.strings
+++ b/pt.lproj/Localizable.strings
@@ -15,8 +15,8 @@
 "nfc_create_sms_title" = "Gerar SMS";
 "nfc_create_tel_title" = "Gerar número telefônico";
 "nfc_create_shortcut_title" = "Gerar atalho";
-"nfc_read_help_title" = "Ler ajuda";
-"nfc_write_help_title" = "Escrever ajuda";
+"nfc_read_help_title" = "Ajuda com leitura";
+"nfc_write_help_title" = "Ajuda com gravação";
 "nfc_licenses_title" = "Licenças";
 "nfc_pro_title" = "Pro";
 "nfc_donation_title" = "Doação";

--- a/pt.lproj/Store-Keywords-100-characters-only.txt
+++ b/pt.lproj/Store-Keywords-100-characters-only.txt
@@ -1,1 +1,1 @@
-scan,read,tag,tags,business,card,scanner,ndef,near,field,implant,uri,vcard,key,qr,nxp,ntag,ring,wifi
+escanear,ler,tag,tags,cartão,visita,scanner,ndef,próximo,campo,implante,uri,vcard,chave,qr,nxp,ntag,anel,wifi


### PR DESCRIPTION
Keywords are limited to 100 characters, but it ended up with 109, although I tried synonyms. I left the choice of which one to remove to the original developer.